### PR TITLE
Add manual calibration and change default sample values

### DIFF
--- a/calibration.cpp
+++ b/calibration.cpp
@@ -1,6 +1,7 @@
 // This file contains functions related to calibration of sensors
 
 #include "calibration.hpp"
+#include "sampling.hpp"
 #include "config.hpp"
 #include <LiquidCrystal.h>
 #include <ACS712.h>
@@ -28,7 +29,7 @@ void calibACS(ACS712 ACS, LiquidCrystal lcd, Servo servo){
 	servo.attach(SERVOPIN);		// Attach servo to output pin
 
 	// Print debug message on display
-	lcd.setCursor(0,0);				// Return cursor
+	lcd.setCursor(0,0);				// Return cursor 
 	lcd.print("Complete       ");
 	lcd.setCursor(0,1);				// Set cursor to next line
 	lcd.print("Midpoint: ");
@@ -38,4 +39,19 @@ void calibACS(ACS712 ACS, LiquidCrystal lcd, Servo servo){
 	Serial.print("Midpoint set to ");
 	Serial.println(midpoint);
 	delay(1000);
+}
+
+float manualCalibration(ACS712 ACS, LiquidCrystal lcd) {
+  lcd.setCursor(0,0);
+  lcd.print("Manual          ");
+  lcd.setCursor(0,1);
+  lcd.print("calibration...  ");
+  delay(1000);
+  float manual_calib = getma(ACS, SAMPLES);
+  lcd.clear();
+  lcd.print("Value: ");
+  lcd.print(manual_calib);
+  lcd.print("mA");
+  delay(2000);
+  return manual_calib;
 }

--- a/calibration.hpp
+++ b/calibration.hpp
@@ -11,5 +11,7 @@
 
 // Calibrating ACS712 module
 void calibACS(ACS712, LiquidCrystal, Servo);
+// Manual calibration by current value
+float manualCalibration(ACS712 ACS, LiquidCrystal lcd);
 
 #endif

--- a/config.hpp
+++ b/config.hpp
@@ -1,12 +1,13 @@
 // Configuration file for pinouts
 
 // Settings
-#define BAUD 9600				// Baud rate
-#define DSAMPLES 200		// Number of samples to capture for calculating "real time" average
-#define SAMPLES 5000		// Number of samples to capture for calculating average on button press
-#define DELAY	100				// Small delay to slow things down
-#define SERVOCTR 90			// Servo center position
-#define DEBOUNCE 50			// Debounce delay
+#define BAUD 9600				     // Baud rate
+#define DSAMPLES 500		     // Number of samples to capture for calculating "real time" average
+#define SAMPLES 10000		     // Number of samples to capture for calculating average on button press
+#define DELAY	100				     // Small delay to slow things down
+#define SERVOCTR 90			     // Servo center position
+#define DEBOUNCE 50			     // Debounce delay
+#define MANUAL_CALIB_DELAY 2 // Seconds the button needs to be pressed to enter manual calibration
 
 // Pinouts
 #define POTPIN 0				// Analog input pin for servo potentiometer

--- a/sampling.cpp
+++ b/sampling.cpp
@@ -21,5 +21,10 @@ int16_t getma(ACS712 acs, uint16_t samples){
 	}
 
 	// Divides sum of all readings by the number of samples (average)
-	return avg = total / samples;
+  // and returns the absolute value
+  avg = total / samples;
+  if(avg >= 0) {
+    return avg;
+  }
+  else return -avg;
 }


### PR DESCRIPTION
Added manual calibration mode by holding the button for 2 seconds (default).
This is achieved by changing the hold variable in main.ino to change only
when the button press is released. A manualCalibration() function was created
in sampling.cpp to handle the task.

Also changed real time sampling value to 500 (was 200) and average sampling
value to 10000 (was 5000). The first was important because the numbers were
changing very quickly on the display, making it really hard to see sudden changes.

Deleted an unused variable in main.ino, 'mamp', which is now in calibration.cpp.

Closes #4